### PR TITLE
adding S3 tags, versioning and other updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## Changelog
+
+### `1.2.4`
+
+- Add `aws_s3_bucket_versioning`, and tag s3 buckets per org guidelines.

--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ Both www and apex A records are created and pointed to a CloudFront distribution
 | zone             | Route53 zone name                                 | string | n/a |   yes    |
 | source_subdomain | FQDN of subdomain that we want to redirect from   | string | n/a |    no    |
 
+## To Deploy
+* Merge new version into `master`
+* `git checkout master`
+* `git pull`
+* `git tag <version-tag>`
+* `git push origin <version-tag>`

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,3 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}

--- a/main.tf
+++ b/main.tf
@@ -1,1 +1,0 @@
-data "aws_region" "current" {}

--- a/variables.tf
+++ b/variables.tf
@@ -19,3 +19,8 @@ variable "allow_overwrite" {
   default     = false
   type        = bool
 }
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}


### PR DESCRIPTION
This PR amends the `terraform-module-route53-domain-redirect` repository and adds the following:
1. Tags for S3 buckets
2. Enables versioning
3. Updates to terraform provider 4.x compatibility
4. A CHANGELOG.md to track versioning and tags for the module.
