### PR TITLE
TTSD-5652 enforce minimum TLS version 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-### `1.3.0`
+### `1.2.7`
 
 - specify minimum SSL protocol as `TLSv1.2_2021`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### `1.3.0`
+
+- specify minimum SSL protocol as `TLSv1.2_2021`
+
 ### `1.2.6`
 
 - ignore `web_acl_id` in Cloudfront

--- a/README.md
+++ b/README.md
@@ -4,16 +4,7 @@
 
 This Terraform module works together with AWS Route53, S3, ACM and CloudFront to create permanent redirect of a domain to a target URL.
 
-Both www and apex A records are created and pointed to a CloudFront distribution. The distribution accepts HTTP and HTTPS* connections (free autorenewing ACM certificate is used for HTTPS). The origin for CloudFront distribution is a S3 hosted website with redirect-all rule. This solution is cheap and maintenance free.
-
-## Disclaimer
-
-* = Please note that while the distribution accepts HTTPS connections, the "vanity" domain that it creates behind the scenes may accept insecure SSL protocols (e.g. TLS 1.0 and TLS 1.1). So if you are utilizing this module to create redirects on publicly accessible domains, they may trip the SecOps's teams security scans. However, since this module redirects traffic to non-vanity domains (which hopefully don't accept insecure TLS protocols), the risk should be low. If you [communicate this to the SecOps team](https://ibotta.atlassian.net/wiki/spaces/SEC/pages/2305269274/Communicating+With+The+SecOps+Team), they should be able to mark it as such.
-
-References:
-* https://ibotta.atlassian.net/browse/TTSD-5652
-* https://www.reddit.com/r/aws/comments/156w1fh/disable_tls_v10_and_v11/
-* https://www.reddit.com/r/aws/comments/don7nl/how_to_disable_cloudfront_tls_v10_without_a/
+Both www and apex A records are created and pointed to a CloudFront distribution. The distribution accepts HTTP and HTTPS connections (free autorenewing ACM certificate is used for HTTPS). The origin for CloudFront distribution is a S3 hosted website with redirect-all rule. This solution is cheap and maintenance free.
 
 **Requirements:** DNS Zone in Route53
 

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -46,8 +46,9 @@ resource "aws_cloudfront_distribution" "redirect" {
   }
 
   viewer_certificate {
-    acm_certificate_arn = aws_acm_certificate.cert.arn
-    ssl_support_method  = "sni-only"
+    acm_certificate_arn      = aws_acm_certificate.cert.arn
+    minimum_protocol_version = "TLSv1.2_2021"
+    ssl_support_method       = "sni-only"
   }
 
   tags = var.tags


### PR DESCRIPTION
See ticket for more information.

[Previous changes](https://github.com/Ibotta/terraform-module-route53-domain-redirect/commit/9629a1d60225d58edfaf9e1f62ff7e43c7b75fc5) to enforce TLS version 1.2 only changed it for TLS to the origin, not to the client. This PR attempts to fix that.

> A recent scan review shows that TLS v1.0 & TLS v1.1 is enabled on the [dashboard.ibotta.com](http://dashboard.ibotta.com/) endpoint.

PR for consuming it: https://github.com/Ibotta/ipn-portal-infrastructure/pull/136