### PR TITLE
Add workaround to remove trailing slash in S3 redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .idea
 .vscode
+
+.terraform.lock.hcl
+.terraform/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### `1.2.8`
 
-- Add variable `remove_trailing_slash` to allow removing trailing slash automicatically added by S3 to the target URL.
+- Add variable `remove_trailing_slash` to allow removing trailing slash automatically added by S3 to the target URL.
 
 ### `1.2.7`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### `1.2.8`
+
+- Add variable `remove_trailing_slash` to allow removing trailing slash automicatically added by S3 to the target URL.
+
 ### `1.2.7`
 
 - specify minimum SSL protocol as `TLSv1.2_2021`

--- a/README.md
+++ b/README.md
@@ -53,16 +53,25 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | n/a | yes |
-| <a name="input_target_url"></a> [target\_url](#input\_target\_url) | URL to redirect to | `string` | n/a | yes |
 | <a name="input_zone"></a> [zone](#input\_zone) | Route53 zone name | `string` | n/a | yes |
 | <a name="input_allow_overwrite"></a> [allow\_overwrite](#input\_allow\_overwrite) | Allow route53 to overwrite the current rule | `bool` | `false` | no |
+| <a name="input_remove_trailing_slash"></a> [remove\_trailing\_slash](#input\_remove\_trailing\_slash) | Remove trailing slash automicatically added by S3 to the target URL. Conflicts with target\_url. | `map(string)` | `{}` | no |
 | <a name="input_source_subdomain"></a> [source\_subdomain](#input\_source\_subdomain) | FQDN of subdomain that we want to redirect from. | `string` | `""` | no |
+| <a name="input_target_url"></a> [target\_url](#input\_target\_url) | URL to redirect to | `string` | `null` | no |
 
 ## Outputs
 
 No outputs.
 
 ## Changelog
+
+### `1.2.8`
+
+- Add variable `remove_trailing_slash` to allow removing trailing slash automicatically added by S3 to the target URL.
+
+### `1.2.7`
+
+- specify minimum SSL protocol as `TLSv1.2_2021`
 
 ### `1.2.6`
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ No modules.
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | n/a | yes |
 | <a name="input_zone"></a> [zone](#input\_zone) | Route53 zone name | `string` | n/a | yes |
 | <a name="input_allow_overwrite"></a> [allow\_overwrite](#input\_allow\_overwrite) | Allow route53 to overwrite the current rule | `bool` | `false` | no |
-| <a name="input_remove_trailing_slash"></a> [remove\_trailing\_slash](#input\_remove\_trailing\_slash) | Remove trailing slash automicatically added by S3 to the target URL. Conflicts with target\_url. | `map(string)` | `{}` | no |
+| <a name="input_remove_trailing_slash"></a> [remove\_trailing\_slash](#input\_remove\_trailing\_slash) | Remove trailing slash automatically added by S3 to the target URL. Conflicts with target\_url. | `map(string)` | `{}` | no |
 | <a name="input_source_subdomain"></a> [source\_subdomain](#input\_source\_subdomain) | FQDN of subdomain that we want to redirect from. | `string` | `""` | no |
 | <a name="input_target_url"></a> [target\_url](#input\_target\_url) | URL to redirect to | `string` | `null` | no |
 
@@ -67,7 +67,7 @@ No outputs.
 
 ### `1.2.8`
 
-- Add variable `remove_trailing_slash` to allow removing trailing slash automicatically added by S3 to the target URL.
+- Add variable `remove_trailing_slash` to allow removing trailing slash automatically added by S3 to the target URL.
 
 ### `1.2.7`
 

--- a/s3.tf
+++ b/s3.tf
@@ -45,7 +45,28 @@ resource "aws_s3_bucket_acl" "redirect_bucket" {
 
 resource "aws_s3_bucket_website_configuration" "redirect_bucket" {
   bucket = aws_s3_bucket.redirect_bucket.id
-  redirect_all_requests_to {
-    host_name = var.target_url
+  dynamic "redirect_all_requests_to" {
+    for_each = var.target_url != null ? [1] : []
+    content {
+      host_name = var.target_url
+    }
+  }
+
+  dynamic "index_document" {
+    for_each = length(keys(var.remove_trailing_slash)) > 0 ? [1] : []
+    content {
+      suffix = "index.html"
+    }
+  }
+
+  dynamic "routing_rule" {
+    for_each = length(keys(var.remove_trailing_slash)) > 0 ? [1] : []
+    content {
+      redirect {
+        host_name        = try(var.remove_trailing_slash.host_name, null)
+        replace_key_with = try(var.remove_trailing_slash.replace_key_with, null)
+      }
+    }
+
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ variable "allow_overwrite" {
 }
 
 variable "remove_trailing_slash" {
-  description = "Remove trailing slash automicatically added by S3 to the target URL. Conflicts with target_url."
+  description = "Remove trailing slash automatically added by S3 to the target URL. Conflicts with target_url."
   type        = map(string)
   default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,7 @@ variable "zone" {
 variable "target_url" {
   description = "URL to redirect to"
   type        = string
+  default     = null
 }
 
 variable "source_subdomain" {
@@ -18,6 +19,12 @@ variable "allow_overwrite" {
   description = "Allow route53 to overwrite the current rule"
   default     = false
   type        = bool
+}
+
+variable "remove_trailing_slash" {
+  description = "Remove trailing slash automicatically added by S3 to the target URL. Conflicts with target_url."
+  type        = map(string)
+  default     = {}
 }
 
 variable "tags" {


### PR DESCRIPTION
Adding variable `remove_trailing_slash` to workaround trailing slash in S3 redirect as described [here](https://repost.aws/knowledge-center/s3-static-website-url-trailing-slash)