### PR TITLE
TTSD-6447: Redirect cache TTL variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### `1.2.9`
+- Add variable `ttl` to allow setting the min, max, and default cache TTL for Cloudfront.
+  - Defaults to the original value of "31536000" (1 year).
+
 ### `1.2.8`
 
 - Add variable `remove_trailing_slash` to allow removing trailing slash automatically added by S3 to the target URL.

--- a/README.md
+++ b/README.md
@@ -58,12 +58,17 @@ No modules.
 | <a name="input_remove_trailing_slash"></a> [remove\_trailing\_slash](#input\_remove\_trailing\_slash) | Remove trailing slash automatically added by S3 to the target URL. Conflicts with target\_url. | `map(string)` | `{}` | no |
 | <a name="input_source_subdomain"></a> [source\_subdomain](#input\_source\_subdomain) | FQDN of subdomain that we want to redirect from. | `string` | `""` | no |
 | <a name="input_target_url"></a> [target\_url](#input\_target\_url) | URL to redirect to | `string` | `null` | no |
+| <a name="input_ttl"></a> [ttl](#input\_ttl) | TTL object to hold the TTL values for min, max and default for the record. | <pre>map(object({<br>    min     = number<br>    max     = number<br>    default = number<br>  }))</pre> | <pre>{<br>  "default": 31536000,<br>  "max": 31536000,<br>  "min": 31536000<br>}</pre> | no |
 
 ## Outputs
 
 No outputs.
 
 ## Changelog
+
+### `1.2.9`
+- Add variable `ttl` to allow setting the min, max, and default cache TTL for Cloudfront.
+  - Defaults to the original value of "31536000" (1 year).
 
 ### `1.2.8`
 

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -30,9 +30,9 @@ resource "aws_cloudfront_distribution" "redirect" {
     target_origin_id = aws_s3_bucket.redirect_bucket.bucket
     compress         = true
 
-    min_ttl     = 31536000
-    max_ttl     = 31536000
-    default_ttl = 31536000
+    min_ttl     = var.ttl.min
+    max_ttl     = var.ttl.max
+    default_ttl = var.ttl.default
 
     forwarded_values {
       query_string = false

--- a/variables.tf
+++ b/variables.tf
@@ -11,20 +11,34 @@ variable "target_url" {
 
 variable "source_subdomain" {
   description = "FQDN of subdomain that we want to redirect from."
-  default     = ""
   type        = string
+  default     = ""
 }
 
 variable "allow_overwrite" {
   description = "Allow route53 to overwrite the current rule"
-  default     = false
   type        = bool
+  default     = false
 }
 
 variable "remove_trailing_slash" {
   description = "Remove trailing slash automatically added by S3 to the target URL. Conflicts with target_url."
   type        = map(string)
   default     = {}
+}
+
+variable "ttl" {
+  description = "TTL object to hold the TTL values for min, max and default for the record."
+  type = map(object({
+    min     = number
+    max     = number
+    default = number
+  }))
+  default = {
+    min     = 31536000
+    max     = 31536000
+    default = 31536000
+  }
 }
 
 variable "tags" {


### PR DESCRIPTION
Story
------------

[TTSD-6447](https://ibotta.atlassian.net/browse/TTSD-6447)

Background
------------
We need to be able to better control cache TTL for redirects. This specific use cases is for the updating of our investor relations subdomain redirect every quarter for quarterly earnings registration.

I'm Feeling
------------

![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExcmU3dnB4M2loZmZ6eXV0aWs4eXg3OThhcTJrMzEwNG5lNngzejAxOCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/vp5ZHZ6OI31LO/giphy.gif)

[TTSD-6447]: https://ibotta.atlassian.net/browse/TTSD-6447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ