### PR TITLE
Fix duplicate url scheme

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -48,7 +48,8 @@ resource "aws_s3_bucket_website_configuration" "redirect_bucket" {
   dynamic "redirect_all_requests_to" {
     for_each = var.target_url != null ? [1] : []
     content {
-      host_name = var.target_url
+      host_name = startswith(var.target_url, "https://") ? trimprefix(var.target_url, "https://") : var.target_url
+      protocol  = "https"
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -29,7 +29,7 @@ variable "remove_trailing_slash" {
 
 variable "ttl" {
   description = "TTL object to hold the TTL values for min, max and default for the record."
-  type       = object({
+  type = object({
     min     = number
     max     = number
     default = number


### PR DESCRIPTION
Right now if you put in a target of `https://mydomain.com/thing` it'll redirect you to `http://https://mydomain.com/thing`.

This hardcodes things so S3 always sends you to https (who is redirecting to something without https these days anyway?) and removes `https://` from the start of the target_url if it is present.